### PR TITLE
Exceptions raised in request decorator fix

### DIFF
--- a/simplemdmapi/decorators.py
+++ b/simplemdmapi/decorators.py
@@ -5,14 +5,6 @@ from typing import Callable, Optional
 from .utils import api_error_check, consume_func_kwargs, consume_kwargs, generate_url, session_retry
 from .validators import validate_any, validate_incompatible, validate_package, validate_param_opts, validate_required
 
-# from time import sleep
-
-# def _wait(s: int | float) -> None:
-#     """Perform a wait between each request.
-#     :param s: time value in seconds"""
-#     if s > 0:
-#         sleep(s)
-
 
 def method_params(fn: Callable) -> Callable:
     """Decorator for performing validations and other actions on an API method.
@@ -83,7 +75,6 @@ def paginate(fn: Callable) -> Callable:
 
         if not self.dry_run:
             while paginate:
-                # _wait(self.HTTP_SLEEP_WAIT)
                 response = self.get(*args, **kwargs)
                 json_data = response.json()
                 objects = json_data.get("data", [])
@@ -131,8 +122,6 @@ def request(method: str) -> Callable:
             self.session.mount("https://", session_retry(self, retry))
 
             if not self.dry_run:
-                # _wait(self.HTTP_SLEEP_WAIT)
-
                 if fieldname and rqst_kwargs.get("files"):
                     file = Path(rqst_kwargs["files"].get(fieldname)).expanduser().resolve()
 

--- a/simplemdmapi/decorators.py
+++ b/simplemdmapi/decorators.py
@@ -147,7 +147,7 @@ def request(method: str) -> Callable:
                 else:
                     response = self.session.request(method, url, **rqst_kwargs)
 
-                    if response.status_code not in ignore or response.status_code not in self.HTTP_RETRY_STATUS_LIST:
+                    if response.status_code not in ignore:
                         api_error_check(response)  # this should catch API specific error responses
                         response.raise_for_status()  # this should catch HTTP connection exceptions that are missed
 


### PR DESCRIPTION
Fixes bad logic for ignoring certain valid "bad" HTTP response codes that SimpleMDM responds with to indicate "valid" states.

Also deletes some commented out functions.